### PR TITLE
Fix for imports using propertyName

### DIFF
--- a/lib/json-schema-to-suretype.ts
+++ b/lib/json-schema-to-suretype.ts
@@ -358,7 +358,7 @@ function createImportHeader(
 		...( TypeOf ? [ 'TypeOf' ] : [ ] ),
 	]
 	.map( name =>
-		factory.createImportSpecifier( undefined, t.ident( name ) )
+		factory.createImportSpecifier( undefined, undefined, t.ident( name ) )
 	);
 	return factory.createImportDeclaration(
 		undefined, // decorators


### PR DESCRIPTION
They should be using name as `propertyName` forces the `as` syntax. when setting a `propertyName` without  a `name` the import is broken. 

You can see the results of the issue here. https://github.com/grantila/typeconv/issues/18